### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
 pickledb = "0.4.1"
-libp2p = "0.38.0"
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 tokio = { version = "1.12.0", features = ["full"] }
@@ -64,4 +63,3 @@ state = { path = "../state" }
 miner = { path = "../miner" }
 blockchain = { path = "../blockchain" }
 validator = { path = "../validator" }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,6 @@ use udp2p::utils::utils::ByteRep;
 use network::message;
 use std::io::{Read, Write};
 use std::net::{SocketAddrV4, SocketAddrV6};
-use state::state::StateUpdateHead;
 
 pub const VALIDATOR_THRESHOLD: f64 = 0.60;
 


### PR DESCRIPTION
Removes `libp2p` and an unused non-existent import that broke `vrrb`'s build